### PR TITLE
Fix broken headings in Markdown files

### DIFF
--- a/README.md
+++ b/README.md
@@ -74,7 +74,7 @@ namer.loadSync();
 // And yes, you can still use your own file
 namer.loadSync('path/to/my/animals.json');
 ```
-#API
+# API
 
 Thanks to the [Nicole Whitehead](https://github.com/ncwhitehead), animal-namer is now available as an API at [animal-namer-api](https://github.com/ncwhitehead/animal-namer-api). The API is available to hit at [Whimsical Wordimal](http://www.whimsicalwordimal.com/).
 


### PR DESCRIPTION
GitHub changed the way Markdown headings are parsed, so this change fixes it.

See [bryant1410/readmesfix](https://github.com/bryant1410/readmesfix) for more information.

Tackles bryant1410/readmesfix#1
